### PR TITLE
Added bounds to LCP calculation. Added tests for LCP array and more sample output.

### DIFF
--- a/cpp/strings/suffix-array.cpp
+++ b/cpp/strings/suffix-array.cpp
@@ -3,7 +3,7 @@
 using namespace std;
 
 // build suffix array in O(n*log(n))
-vector<int> suffix_array(const string &S) {
+vector<int> suffix_array(const string& S) {
     int n = S.length();
 
     // Stable sort of characters.
@@ -50,8 +50,10 @@ vector<int> suffix_array(const string &S) {
     return sa;
 }
 
+#define IS_VALID_INDEX(i, h, j, n) (i + h < n && j + h < n)
+
 // https://en.wikipedia.org/wiki/LCP_array
-vector<int> lcp_array(const string &s) {
+vector<int> lcp_array(const string& s) {
     int n = s.size();
     vector<int> sa = suffix_array(s);
     vector<int> rank(n);
@@ -60,7 +62,7 @@ vector<int> lcp_array(const string &s) {
     vector<int> lcp(n - 1);
     for (int i = 0, h = 0; i < n; i++) {
         if (rank[i] < n - 1) {
-            for (int j = sa[rank[i] + 1]; s[i + h] == s[j + h]; ++h)
+            for (int j = sa[rank[i] + 1]; IS_VALID_INDEX(i, h, j, n) && s[i + h] == s[j + h]; ++h)
                 ;
             lcp[rank[i]] = h;
             if (h > 0)
@@ -70,8 +72,61 @@ vector<int> lcp_array(const string &s) {
     return lcp;
 }
 
+void test_lcp_array() {
+    // Test 1: Simple case with no common prefixes
+    string s1 = "abcd";
+    vector<int> lcp1 = lcp_array(s1);
+    cout << "Test 1 - Expected: [], Got: ";
+    for (int v : lcp1)
+        cout << v << " ";
+    cout << endl;  // Expected output: []
+
+    // Test 2: Simple case with repeated substring
+    string s2 = "abab";
+    vector<int> lcp2 = lcp_array(s2);
+    cout << "Test 2 - Expected: [2, 0, 1], Got: ";
+    for (int v : lcp2)
+        cout << v << " ";
+    cout << endl;  // Expected output: [2, 0, 1]
+
+    // Test 3: String with full repetition // is test correct?
+    string s3 = "aaaa";
+    vector<int> lcp3 = lcp_array(s3);
+    cout << "Test 3 - Expected: [3, 2, 1], Got: ";
+    for (int v : lcp3)
+        cout << v << " ";
+    cout << endl;  // Expected output: [3, 2, 1]
+
+    // Test 4: String with unique characters
+    string s4 = "abcdef";
+    vector<int> lcp4 = lcp_array(s4);
+    cout << "Test 4 - Expected: [], Got: ";
+    for (int v : lcp4)
+        cout << v << " ";
+    cout << endl;  // Expected output: []
+
+    // Test 5: Edge case: Empty string
+    // string s5 = "";
+    // vector<int> lcp5 = lcp_array(s5);
+    // cout << "Test 5 - Expected: [], Got: ";
+    // for (int v : lcp5)
+    //     cout << v << " ";
+    // cout << endl;  // Expected output: []
+
+    // Test 6: Single character string
+    string s6 = "a";
+    vector<int> lcp6 = lcp_array(s6);
+    cout << "Test 6 - Expected: [], Got: ";
+    for (int v : lcp6)
+        cout << v << " ";
+    cout << endl;  // Expected output: []
+}
+
 // usage example
 int main() {
+    test_lcp_array();
+
+    cout << "\nExample test for 'abcab'" << endl;
     string s = "abcab";
 
     vector<int> sa = suffix_array(s);
@@ -83,6 +138,19 @@ int main() {
     for (int v : lcp)
         cout << v << " ";
     cout << endl;
+
+    cout << "\nExample test for 'banana'" << endl;
+    string s2 = "banana";
+
+    vector<int> sa2 = suffix_array(s2);
+    for (int v : sa2)
+        cout << v << " ";
+    cout << endl;
+
+    vector<int> lcp2 = lcp_array(s2);
+    for (int v : lcp2)
+        cout << v << " ";
+    cout << endl << endl;
 
     mt19937 rng(1);
     s.clear();


### PR DESCRIPTION
Added bounds to LCP to fix issue [](https://github.com/indy256/codelibrary/issues/180). Added tests for LCP array and more sample output.
example of current output:
"""
Test 1 - Expected: [], Got: 0 0 0        
Test 2 - Expected: [2, 0, 1], Got: 2 0 1 
Test 3 - Expected: [3, 2, 1], Got: 1 2 3
Test 4 - Expected: [], Got: 0 0 0 0 0
Test 6 - Expected: [], Got:

Example test for 'abcab'
3 0 4 1 2
2 0 1 0

Example test for 'banana'
5 3 1 0 4 2
1 3 0 0 2

1678.3 ms
"""